### PR TITLE
Fixing usage of `terragrunt run-all`

### DIFF
--- a/aws-terragrunt-simple-mws/README.md
+++ b/aws-terragrunt-simple-mws/README.md
@@ -16,6 +16,6 @@ You can change both according to your needs in the respective provider configura
 - Run the stack with
 ```shell
 cd live
-terragrunt run-all plan
-terragrunt run-all apply
+terragrunt plan --all
+terragrunt apply --all
 ```


### PR DESCRIPTION
`terragrunt run-all` is deprecated, so replace it with corresponding commands